### PR TITLE
Adding ability to show/hide specific parts of the tooltip

### DIFF
--- a/addon/TheUndermineJournal.toc
+++ b/addon/TheUndermineJournal.toc
@@ -2,7 +2,7 @@
 ## Title: The Undermine Journal
 ## Notes: %s
 ## OptionalDeps: Auctionator, AuctionLite, LibExtraTip
-## SavedVariablesPerCharacter: TUJTooltipsHidden
+## SavedVariablesPerCharacter: TUJTooltipsSettings
 ## Version: 5.5.%s
 
 libs\LibStub.lua


### PR DESCRIPTION
This set of changes is to add the ability to show or hide specific parts of the tooltip.

I converted the saved variable into a table and store all of the settings in the table.

I also made it so that it grabs the saved settings only once, when The Undermine Journal addon is loaded as opposed to every time any addon is loaded.

Each of the lines in the tooltip is now able to be enabled/disabled at will. If the user types "/tujtooltip help" it will display the list of arguments to go along with the /tujtooltip command as well as the current state of each of the lines (if they are On or Off) as well as a short description of what each argument does. If the user tries to use an argument not listed, or misspells an argument, it will then tell them that the argument is not recognized and to run "/tujtooltip help" for the list of arguments.

To keep all original usage the same, I left in the On/Off arguments as well as no argument to automatically switch between the two. So any users familiar with previous usage should not be impacted. I also added ToggleAllOn and ToggleAllOff arguments to toggle all of the settings on or off respectively except for the tooltip container. Mostly for ease of use for users for first time set up on new characters if they only want to show one or two of the lines of the tooltip.

As a feature to reduce possible confusion, I did also add a feature where if the user disables all of the settings (regardless of the overall tooltip container setting), on logout it will re-enable all of the settings and simply disable the tooltip container.